### PR TITLE
Behavior of "." in a symbol set actually means "not a newline"

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -13,6 +13,14 @@ void parseSymbolSet(std::bitset<256> &column, std::string symbol_set) {
         column.set();
         return;
     }
+    
+    // KAA found that apcompile parses symbol-set="." to mean "^\x0a"
+    // hard-coding this here
+    if(symbol_set.compare(".") == 0) {
+        column.set('\n',1);
+        column.flip();
+        return;
+    }
         
     bool in_charset = false;
     bool escaped = false;


### PR DESCRIPTION
"." is a special character.  Adding behavior that matches apcompile to public fork of VASim.