### PR TITLE
Changed uint to unsigned int for support on OS X

### DIFF
--- a/src/automata.cpp
+++ b/src/automata.cpp
@@ -978,7 +978,7 @@ void Automata::printReportBatchSim() {
 
     // print report vector
     for(auto s: reportVector) {
-        uint cycle = s.first + 1;
+        unsigned int cycle = s.first + 1;
         if(id.empty()){
             cout << "Element id: " << s.second << " reporting at index " << to_string(cycle) << endl;
         }else{
@@ -1550,8 +1550,8 @@ void Automata::automataToNFAFile(string out_fn) {
     unordered_map<string, int> id_map;
     unordered_map<string, bool> marked;
     queue<string> to_process;
-    uint state_counter = 0;
-    uint accept_counter = 1;
+    unsigned int state_counter = 0;
+    unsigned int accept_counter = 1;
 
     string str = "";
 


### PR DESCRIPTION
Building always breaks for me on OS X.  Changing uint to unsigned int fixes these errors.