### PR TITLE
Fix errors in parsing symbol set

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -275,7 +275,7 @@ void parseSymbolSet(std::bitset<256> &column, std::string symbol_set) {
             }else{
                 column.set(c, value);
                 if(range_set){
-                    setRange(column,range_start,'\r',value);
+                    setRange(column,range_start,c,value);
                     range_set = false;
                 }
                 last_char = c;
@@ -285,7 +285,7 @@ void parseSymbolSet(std::bitset<256> &column, std::string symbol_set) {
             if(escaped){
                 column.set('\t',value);
                 if(range_set){
-                    setRange(column,range_start,'\r',value);
+                    setRange(column,range_start,'\t',value);
                     range_set = false;
                 }
                 last_char = '\t';


### PR DESCRIPTION
Both appear to be copy-paste errors.

The error with `\r` turns up in RandomForest, where the symbol set for element `6_18_3` is misparsed.

The set `[^j-r\xd5-\xff]` should be `[\x00-\x69\x73-\xd4]` (`vasim -a`), rather than `[\x00-\x69\x6b-\x71\x73-\xd4]`

The second error with `\t` has not showed up (AFAICT), but it does appear to be an error too.