### PR TITLE
Fix undefined behavior in element.cpp

### DIFF
--- a/include/element.h
+++ b/include/element.h
@@ -77,7 +77,7 @@ public:
     std::vector<std::pair<Element *, std::string>> getOutputSpecelPointers();
     bool clearOutputs();
     bool clearOutputPointers();
-    bool clearInputs();
+    void clearInputs();
     std::map<std::string, bool> getInputs();
     bool addOutput(std::string);
     bool addOutputPointer(std::pair<Element *, std::string>);

--- a/src/MNRLAdapter.cpp
+++ b/src/MNRLAdapter.cpp
@@ -41,6 +41,9 @@ static string convertThreshold(MNRLDefs::CounterMode m) {
             return "latch";
         case MNRLDefs::CounterMode::ROLLOVER_ON_THRESHOLD:
             return "roll";
+        default:
+            cerr << "Unknown counter mode. Exiting." << endl;
+            exit(1);
     }
 }
 

--- a/src/element.cpp
+++ b/src/element.cpp
@@ -306,7 +306,7 @@ bool Element::clearOutputPointers() {
     return true;
 }
 
-bool Element::clearInputs() {
+void Element::clearInputs() {
 
     inputs.clear();
 }


### PR DESCRIPTION
Previously, `clearInputs()` is declared as: 

`bool clearInputs();` in `include/element.h`.

However, in its definition in `src/element.cpp`, it does not actually have a return statement. This is undefined behavior and causes crashes when compiled using gcc 11.4 (and probably many other versions too!)

This PR changes the type of `clearInputs()` to a `void` function to fix this undefined behavior.

It also makes a similar (though less critical) fix to `convertThreshold` in `MNRLAdapter.cpp`. 